### PR TITLE
feat: pass client's IP address and port to ASGI app via scope 'client'

### DIFF
--- a/a2wsgi/asgi.py
+++ b/a2wsgi/asgi.py
@@ -85,7 +85,7 @@ def build_scope(environ: Environ) -> Scope:
         "path": environ["PATH_INFO"].encode("latin1").decode("utf8"),
         "query_string": environ["QUERY_STRING"].encode("ascii"),
         "root_path": environ.get("SCRIPT_NAME", "").encode("latin1").decode("utf8"),
-        "client": None,
+        "client": (environ.get("REMOTE_ADDR"), environ.get("REMOTE_PORT")),
         "server": (environ["SERVER_NAME"], int(environ["SERVER_PORT"])),
         "headers": headers,
     }

--- a/a2wsgi/asgi.py
+++ b/a2wsgi/asgi.py
@@ -85,7 +85,7 @@ def build_scope(environ: Environ) -> Scope:
         "path": environ["PATH_INFO"].encode("latin1").decode("utf8"),
         "query_string": environ["QUERY_STRING"].encode("ascii"),
         "root_path": environ.get("SCRIPT_NAME", "").encode("latin1").decode("utf8"),
-        "client": (environ.get("REMOTE_ADDR"), environ.get("REMOTE_PORT")),
+        "client": (environ.get("REMOTE_ADDR"), int(environ.get("REMOTE_PORT"))),
         "server": (environ["SERVER_NAME"], int(environ["SERVER_PORT"])),
         "headers": headers,
     }


### PR DESCRIPTION
This PR will enable the ASGI application to access the client's IP address and the client's port by the tuple `(client_ip, client_port)` in `scope["client"]`.

Note: needs testing.

Closes #5