### PR TITLE
fix: Set an empty stream if wsgi.input does not exists.

### DIFF
--- a/a2wsgi/asgi.py
+++ b/a2wsgi/asgi.py
@@ -1,5 +1,6 @@
 import asyncio
 import collections
+from io import StringIO
 import threading
 from http import HTTPStatus
 from itertools import chain
@@ -174,7 +175,7 @@ class ASGIResponder:
         )
         run_asgi.add_done_callback(_done_callback)
 
-        read_count, body = 0, environ["wsgi.input"]
+        read_count, body = 0, environ.get("wsgi.input", StringIO())
         content_length = int(environ.get("CONTENT_LENGTH", None) or 0)
 
         self.loop.call_soon_threadsafe(lambda: None)

--- a/a2wsgi/asgi.py
+++ b/a2wsgi/asgi.py
@@ -1,8 +1,8 @@
 import asyncio
 import collections
-from io import StringIO
 import threading
 from http import HTTPStatus
+from io import BytesIO
 from itertools import chain
 from typing import Any, Deque, Iterable
 
@@ -175,7 +175,7 @@ class ASGIResponder:
         )
         run_asgi.add_done_callback(_done_callback)
 
-        read_count, body = 0, environ.get("wsgi.input", StringIO())
+        read_count, body = 0, environ["wsgi.input"] or BytesIO()
         content_length = int(environ.get("CONTENT_LENGTH", None) or 0)
 
         self.loop.call_soon_threadsafe(lambda: None)


### PR DESCRIPTION
Fixes #26

This PR will be changed to set an empty stream to```wsgi.input``` if ```wsgi.input``` was None.