### PR TITLE
Convert to pdm-backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,5 +35,5 @@ benchmark = [
 includes = ["a2wsgi"]
 
 [build-system]
-build-backend = "pdm.pep517.api"
-requires = ["pdm-pep517>=1.0.0"]
+build-backend = "pdm.backend"
+requires = ["pdm-backend"]


### PR DESCRIPTION
Replace the deprecated pdm-pep517 backend with pdm-backend that superseded it.  No changes are required, and the output artifacts are equivalent.  The migration guide is at:
https://pdm-backend.fming.dev/migration/