### PR TITLE
Use thread-safe API to call things on ASGIResponder.loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Tests
         run: pdm run pytest tests -o log_cli=true -o log_cli_level=DEBUG
+        env:
+          PYTHONASYNCIODEBUG: 1
 
   publish:
     needs: tests


### PR DESCRIPTION
This wraps calls to the event loop in thread-safe functions.
`PYTHONASYNCIODEBUG` is added to GitHub actions to detect similar issues.

There might be a more elegant way to do this, but I didn't find it.

Fixes: #53