### PR TITLE
Require typing_extensions on Python < 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,9 @@
 [project]
 authors = [{ name = "abersheeran", email = "me@abersheeran.com" }]
 classifiers = ["Programming Language :: Python :: 3"]
-dependencies = []
+dependencies = [
+  "typing_extensions; python_version<'3.11'"
+]
 description = "Convert WSGI app to ASGI app or ASGI app to WSGI app."
 license = { text = "Apache-2.0" }
 name = "a2wsgi"


### PR DESCRIPTION
`asgi_typing.py` has:
```python
if sys.version_info >= (3, 11):
    from typing import NotRequired
else:
    from typing_extensions import NotRequired
```
However, `typing_extensions` was not listed as a runtime requirement. If a2wsgi was installed without its test dependencies (which themselves require `typing_extensions`), it failed to import.

Fixes: #52