### PR TITLE
Fix ASGIMiddleware Receive

### DIFF
--- a/a2wsgi/asgi.py
+++ b/a2wsgi/asgi.py
@@ -254,12 +254,17 @@ class ASGIResponder:
 
             if message_type == "receive":
                 read_size = min(65536, content_length - read_count)
-                data: bytes = body.read(read_size)
-                read_count += len(data)
-                more_body = read_count < content_length
-                self.async_event.set(
-                    {"type": "http.request", "body": data, "more_body": more_body}
-                )
+                if read_size == 0:  # No more body, so don't read anymore
+                    self.async_event.set(
+                        {"type": "http.request", "body": b"", "more_body": False}
+                    )
+                else:
+                    data: bytes = body.read(read_size)
+                    read_count += len(data)
+                    more_body = read_count < content_length
+                    self.async_event.set(
+                        {"type": "http.request", "body": data, "more_body": more_body}
+                    )
             else:
                 self.async_event.set(None)
 

--- a/pdm.lock
+++ b/pdm.lock
@@ -2,10 +2,10 @@
 # It is not intended for manual editing.
 
 [metadata]
-groups = ["default", "benchmark", "dev"]
+groups = ["default", "benchmark", "dev", "test"]
 strategy = ["cross_platform"]
 lock_version = "4.4.1"
-content_hash = "sha256:04b453f6930ee54954cb3995dfa10b60f119b494ef5413bd3cc91fe4ab5819dc"
+content_hash = "sha256:9f8a35ba53b9a111460c2aebef280db45baea8d1711c4ad586e13cf60c796bf6"
 
 [[package]]
 name = "anyio"
@@ -443,6 +443,20 @@ summary = "Sniff out which async library your code is running under"
 files = [
     {file = "sniffio-1.2.0-py3-none-any.whl", hash = "sha256:471b71698eac1c2112a40ce2752bb2f4a4814c22a54a3eed3676bc0f5ca9f663"},
     {file = "sniffio-1.2.0.tar.gz", hash = "sha256:c4666eecec1d3f50960c6bdf61ab7bc350648da6c126e3cf6898d8cd4ddcd3de"},
+]
+
+[[package]]
+name = "starlette"
+version = "0.37.2"
+requires_python = ">=3.8"
+summary = "The little ASGI library that shines."
+dependencies = [
+    "anyio<5,>=3.4.0",
+    "typing-extensions>=3.10.0; python_version < \"3.10\"",
+]
+files = [
+    {file = "starlette-0.37.2-py3-none-any.whl", hash = "sha256:6fe59f29268538e5d0d182f2791a479a0c64638e6935d1c6989e63fb2699c6ee"},
+    {file = "starlette-0.37.2.tar.gz", hash = "sha256:9af890290133b79fc3db55474ade20f6220a364a0402e0b556e7cd5e1e093823"},
 ]
 
 [[package]]

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "benchmark", "dev", "test"]
 strategy = ["cross_platform"]
 lock_version = "4.4.1"
-content_hash = "sha256:9f8a35ba53b9a111460c2aebef280db45baea8d1711c4ad586e13cf60c796bf6"
+content_hash = "sha256:122f33dfb4ad2ff1b0e91531982f438c68b586b207f5f2eba7d384ed0ad11ece"
 
 [[package]]
 name = "anyio"
@@ -32,6 +32,28 @@ dependencies = [
 files = [
     {file = "asgiref-3.7.2-py3-none-any.whl", hash = "sha256:89b2ef2247e3b562a16eef663bc0e2e703ec6468e2fa8a5cd61cd449786d4f6e"},
     {file = "asgiref-3.7.2.tar.gz", hash = "sha256:9e0ce3aa93a819ba5b45120216b23878cf6e8525eb3848653452b4192b92afed"},
+]
+
+[[package]]
+name = "baize"
+version = "0.20.8"
+requires_python = ">=3.7"
+summary = "Powerful and exquisite WSGI/ASGI framework/toolkit."
+files = [
+    {file = "baize-0.20.8-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:cee1b5ae52e238b6628a6c1084d4d00276c3a33b0c91e2f158b91c8518a3b723"},
+    {file = "baize-0.20.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7386ea92755cfc35a42aea57f704399d761b19fc5723961fd58e04c38002f146"},
+    {file = "baize-0.20.8-cp310-cp310-win_amd64.whl", hash = "sha256:aaa82265088ccdce541e90cbbcf916dd1a7c950acdfca129603f3ac0f49e03b8"},
+    {file = "baize-0.20.8-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:cb28ea2756891768eb81e9967b52b5ff9fcc768d2b1a0afb46e8b0bc8ec32590"},
+    {file = "baize-0.20.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cf0a818b1a3cc7cef5782c35e16697ba2a7f22446d31eb0014459bcf5dece67a"},
+    {file = "baize-0.20.8-cp311-cp311-win_amd64.whl", hash = "sha256:1c845915e287eadf297e9c9ef138849b3c616965d65e5a228e1c7125b3612624"},
+    {file = "baize-0.20.8-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:5d4e6f2238f1f9211e741ded9bc34297b3d459ec5eac2dd66b2d1a6e3744bc1b"},
+    {file = "baize-0.20.8-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a315ed5feda35324bf2d0fd8b0b424b32e0ee5d02f44ad54d5bb2689b8f40a73"},
+    {file = "baize-0.20.8-cp38-cp38-win_amd64.whl", hash = "sha256:d533592cf076b9c1e5b0b57324de75342024b0ccd9ed23a69bf0a702aec22078"},
+    {file = "baize-0.20.8-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:f3f0a6b7ba006efd1f779107efcc8e01e38aecd63f21f62a046321b654b7c6f8"},
+    {file = "baize-0.20.8-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e910b14b0fe8d8b34c135d0cea94fc9053036b953eaefa8b5f2dd6cc3115bd05"},
+    {file = "baize-0.20.8-cp39-cp39-win_amd64.whl", hash = "sha256:6da5d0c1243a90e54987f7b37ea7e112592fadf9b80d2de4d067307b53770e55"},
+    {file = "baize-0.20.8-py3-none-any.whl", hash = "sha256:562bd3eeca18efd9e2518e8e0e01689b76e0de3368bff71ea3b0b1a5c5c792a5"},
+    {file = "baize-0.20.8.tar.gz", hash = "sha256:966eea93830beb003d8992218483d70fdd8955baedf225e519c8c3a0fe89dd64"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,11 @@ dev = [
 ]
 benchmark = ["uvicorn>=0.16.0", "asgiref>=3.4.1"]
 test = [
-  "pytest<8.0.0,>=7.0.1",
-  "pytest-cov<4.0.0,>=3.0.0",
-  "pytest-asyncio<1.0.0,>=0.11.0",
-  "starlette>=0.37.2",
+    "pytest<8.0.0,>=7.0.1",
+    "pytest-cov<4.0.0,>=3.0.0",
+    "pytest-asyncio<1.0.0,>=0.11.0",
+    "starlette>=0.37.2",
+    "baize>=0.20.8",
 ]
 
 [tool.pdm.build]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,7 @@
 [project]
 authors = [{ name = "abersheeran", email = "me@abersheeran.com" }]
 classifiers = ["Programming Language :: Python :: 3"]
-dependencies = [
-  "typing_extensions; python_version<'3.11'"
-]
+dependencies = ["typing_extensions; python_version<'3.11'"]
 description = "Convert WSGI app to ASGI app or ASGI app to WSGI app."
 license = { text = "Apache-2.0" }
 name = "a2wsgi"
@@ -20,13 +18,16 @@ dev = [
   "asgiref<4.0.0,>=3.2.7",
   "black",
   "flake8",
-  "pytest<8.0.0,>=7.0.1",
-  "pytest-cov<4.0.0,>=3.0.0",
-  "pytest-asyncio<1.0.0,>=0.11.0",
   "mypy",
   "httpx<1.0.0,>=0.22.0",
 ]
 benchmark = ["uvicorn>=0.16.0", "asgiref>=3.4.1"]
+test = [
+  "pytest<8.0.0,>=7.0.1",
+  "pytest-cov<4.0.0,>=3.0.0",
+  "pytest-asyncio<1.0.0,>=0.11.0",
+  "starlette>=0.37.2",
+]
 
 [tool.pdm.build]
 includes = ["a2wsgi"]

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -224,3 +224,19 @@ def test_starlette_base_http_middleware():
         assert response.status_code == 200
         assert response.text == '{"hello":"world"}'
         assert response.headers["x-middleware"] == "true"
+
+
+def test_baize_stream_response():
+    from baize.asgi import StreamResponse
+
+    async def stream():
+        for i in range(10):
+            yield str(i).encode()
+
+    app = ASGIMiddleware(StreamResponse(stream()))
+    with httpx.Client(
+        transport=httpx.WSGITransport(app=app), base_url="http://testserver:80"
+    ) as client:
+        response = client.get("/")
+        assert response.status_code == 200
+        assert response.text == "0123456789"

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -194,3 +194,15 @@ def test_http_content_headers():
     counter = Counter(scope["headers"])
     assert counter[(b"content-type", content_type.encode())] == 1
     assert counter[(b"content-length", content_length.encode())] == 1
+
+
+def test_starlette_stream_response():
+    from starlette.responses import StreamingResponse
+
+    app = ASGIMiddleware(StreamingResponse(content=map(str, range(10))))
+    with httpx.Client(
+        transport=httpx.WSGITransport(app=app), base_url="http://testserver:80"
+    ) as client:
+        response = client.get("/")
+        assert response.status_code == 200
+        assert response.text == "0123456789"


### PR DESCRIPTION
fixes #58 #45 

In Starlette, there are many codes that use receive to determine whether the connection is disconnected and continue to send. The current ASGIMiddleware is designed to save resources and handles two requests in the same thread, which will cause send to be blocked by receive.

https://github.com/encode/starlette/blob/5a1bec33f8d6a669a3670f51034de83292d19408/starlette/responses.py#L257-L265