### PR TITLE
Fix inconsistent HTTPStatus string representation

### DIFF
--- a/a2wsgi/asgi.py
+++ b/a2wsgi/asgi.py
@@ -21,7 +21,7 @@ class defaultdict(dict):
 
 StatusStringMapping = defaultdict(
     lambda status: f"{status} Unknown Status Code",
-    {int(status): f"{status} {status.phrase}" for status in HTTPStatus},
+    {status.value: f"{status.value} {status.phrase}" for status in HTTPStatus},
 )
 
 


### PR DESCRIPTION
Hello,

In some python environments, HTTPStatus conversion to string will not result in their value but in their repr ("<HTTPStatus.OK: 200>" instead of "200")

It leads to the following error in mod_wsgi:
```
ValueError: status code is not a 3 digit integer
```
because the returned status is "<HTTPStatus.OK: 200> OK" instead of "200 OK"

Explicit call to the value property ensure that the fstring contains the numerical representation of the HTTP code and not the human readable representation of the enum.

## mod_wsgi behavior:
```
>>> str(HTTPStatus.OK)
'<HTTPStatus.OK: 200>'
>>> HTTPStatus.OK.__str__
<method-wrapper '__str__' of HTTPStatus object at 0x7fb3d52bbd50>
```

## python CLI behavior
```
>>> str(HTTPStatus.OK)
'200'
>>> HTTPStatus.OK.__str__
<method-wrapper '__repr__' of HTTPStatus object at 0x7faa19c06350>
```

